### PR TITLE
Fix crash when async host receives a packet

### DIFF
--- a/src/ENet.Managed/Async/ENetAsyncHost.cs
+++ b/src/ENet.Managed/Async/ENetAsyncHost.cs
@@ -587,7 +587,7 @@ namespace ENet.Managed.Async
                 case ENetEventType.Receive:
                     asyncPeer = getAsyncPeer();
                     asyncPeer.OnReceive(@event.Packet, @event.ChannelId);
-                    @event.Packet.RemoveRef();
+                    @event.Packet.Destroy();
                     break;
 
                 default:


### PR DESCRIPTION
Before the change ENetAsyncHost was trying to use ref counting but ENetAsyncPacket copies the packet data to a different buffer so I believe it's fine to just `Destroy()` the original packet.

I've had this sitting in a downstream repo and it seems to have been working fine.
